### PR TITLE
Bug fix for chained entries

### DIFF
--- a/inventree_forecasting/forecast.py
+++ b/inventree_forecasting/forecast.py
@@ -19,6 +19,11 @@ class PartForecast:
 
     def __init__(self):
         # Available stock for each intermediate assembly, used to offset demand.
+        # Populated (in `generate_upstream_entries`) for every part visited
+        # during the upstream walk, including the base part being forecasted -
+        # but `post_process_entries` must never spend the base part's own
+        # entry, since its stock is already reflected via the caller's
+        # `in_stock` baseline and its own purchase/build order entries.
         self.assembly_stock = {}
 
         # Per-part query result caches, keyed by part pk. A part reached via
@@ -65,9 +70,21 @@ class PartForecast:
             # Start with the raw quantity required for the entry
             quantity = Decimal(quantity) / Decimal(top_multiplier)
 
-            # For a "chained" entry we iterate backwards down the chain, and offset the quantity by the available stock at each level
+            # For a "chained" entry we iterate backwards down the chain, and offset the quantity by the available stock at each level.
+            #
+            # chain[0] is always the base part being forecasted (the `part`
+            # passed to `get_entries`), never a true intermediate assembly -
+            # deliberately stop at idx=1 and never offset against
+            # `assembly_stock[chain[0][0].pk]`. That part's current stock is
+            # already the caller's `in_stock` baseline that entries are added
+            # on top of (see ForecastingPanel's running total, and
+            # `export_data`), and its incoming purchase/build orders already
+            # appear as their own unmodified (chain=None) positive entries.
+            # Offsetting here too would silently spend that same stock a
+            # second (or third) time, shrinking shortfalls that happen to
+            # route all the way back down to the base part.
             chain_length = len(chain)
-            for idx in range(chain_length - 1, -1, -1):
+            for idx in range(chain_length - 1, 0, -1):
                 part, cumulative_multiplier = chain[idx]
 
                 # How much intermediate stock is available?
@@ -82,16 +99,16 @@ class PartForecast:
                     # If the quantity has been fully offset by available stock, we can stop processing this entry
                     quantity = 0
                     break
-                elif idx > 0:
-                    # Convert the remaining shortfall down to the next (lower)
-                    # level's units, using the ratio between this level's and
-                    # the next level's *cumulative* multipliers - which is the
-                    # per-level BOM ratio between them. Using the cumulative
-                    # multiplier directly here (as opposed to this ratio)
-                    # double-counts every level above the base part.
-                    _, next_cumulative_multiplier = chain[idx - 1]
-                    level_ratio = cumulative_multiplier / next_cumulative_multiplier
-                    quantity *= Decimal(level_ratio)
+
+                # Convert the remaining shortfall down to the next (lower)
+                # level's units, using the ratio between this level's and
+                # the next level's *cumulative* multipliers - which is the
+                # per-level BOM ratio between them. Using the cumulative
+                # multiplier directly here (as opposed to this ratio)
+                # double-counts every level above the base part.
+                _, next_cumulative_multiplier = chain[idx - 1]
+                level_ratio = cumulative_multiplier / next_cumulative_multiplier
+                quantity *= Decimal(level_ratio)
 
             # Update the entry with the post-processed quantity
             entry["quantity"] = quantity

--- a/inventree_forecasting/forecast.py
+++ b/inventree_forecasting/forecast.py
@@ -3,7 +3,6 @@
 from collections import defaultdict
 from datetime import date
 from decimal import Decimal
-from math import prod
 
 import build.models as build_models
 import build.status_codes as build_status
@@ -39,7 +38,7 @@ class PartForecast:
         and we also have a complete picture of the stock availability of any intermediate assemblies
         """
 
-        for idx, entry in enumerate(entries):
+        for entry in entries:
             quantity = entry.get("quantity", 0)
 
             if quantity >= 0:
@@ -51,18 +50,26 @@ class PartForecast:
             if not chain or len(chain) <= 1:
                 continue
 
-            # Work out the total chain multiplier for this entry
-            chain_multiplier = prod([q for p, q in chain])
+            # Each chain entry stores the *cumulative* multiplier (relative to
+            # the base part) up to that level, not the ratio between
+            # consecutive levels - the entry's quantity was generated using
+            # the last (highest-level) chain entry's cumulative multiplier, so
+            # divide that back out to recover the raw outstanding quantity, in
+            # units of that top-level part.
+            top_multiplier = chain[-1][1]
 
-            if chain_multiplier <= 0:
+            if top_multiplier <= 0:
                 # Defensive check - this should not happen, but we want to avoid any potential issues with zero or negative multipliers
                 continue
 
             # Start with the raw quantity required for the entry
-            quantity = Decimal(quantity) / Decimal(chain_multiplier)
+            quantity = Decimal(quantity) / Decimal(top_multiplier)
 
             # For a "chained" entry we iterate backwards down the chain, and offset the quantity by the available stock at each level
-            for part, qty in reversed(chain):
+            chain_length = len(chain)
+            for idx in range(chain_length - 1, -1, -1):
+                part, cumulative_multiplier = chain[idx]
+
                 # How much intermediate stock is available?
                 available = self.assembly_stock.get(part.pk, 0)
 
@@ -75,8 +82,16 @@ class PartForecast:
                     # If the quantity has been fully offset by available stock, we can stop processing this entry
                     quantity = 0
                     break
-                else:
-                    quantity *= Decimal(qty)
+                elif idx > 0:
+                    # Convert the remaining shortfall down to the next (lower)
+                    # level's units, using the ratio between this level's and
+                    # the next level's *cumulative* multipliers - which is the
+                    # per-level BOM ratio between them. Using the cumulative
+                    # multiplier directly here (as opposed to this ratio)
+                    # double-counts every level above the base part.
+                    _, next_cumulative_multiplier = chain[idx - 1]
+                    level_ratio = cumulative_multiplier / next_cumulative_multiplier
+                    quantity *= Decimal(level_ratio)
 
             # Update the entry with the post-processed quantity
             entry["quantity"] = quantity

--- a/inventree_forecasting/tests/test_forecasting.py
+++ b/inventree_forecasting/tests/test_forecasting.py
@@ -425,6 +425,38 @@ class PostProcessEntriesTests(PartForecastTestCase):
         self.assertEqual(result[0]['quantity'], -12)
         self.assertEqual(self.forecast.assembly_stock[intermediate.pk], 0)
 
+    def test_base_part_own_stock_is_never_used_as_an_offset(self):
+        """The base part being forecasted (chain[0]) must never have its own
+        stock spent to offset a chain-derived shortfall, no matter how much
+        is available - only genuinely intermediate levels (chain[1:]) count.
+
+        This matters because the base part's stock is already reflected
+        elsewhere: as the starting point the API/frontend adds every entry's
+        quantity on top of (`in_stock`), and (for on_order/being-built stock)
+        as its own separate, unmodified purchase/build order entries. Letting
+        `post_process_entries` also spend `assembly_stock[chain[0]]` credits
+        that same stock a second time, silently shrinking - or, as here,
+        completely erasing - a real shortfall for any chain that happens to
+        cascade all the way back down to the base part.
+        """
+        intermediate = Part.objects.create(
+            name='Intermediate 6', description='x', assembly=True
+        )
+        # -20 units required at the bottom level, chain multiplier = 2
+        # -> 10 units required of the intermediate part, none available there,
+        # but the base part itself has plenty of "stock" recorded.
+        self.forecast.assembly_stock = {self.part.pk: 1000, intermediate.pk: 0}
+        entries = [self.entry(-20, chain=[(self.part, 1.0), (intermediate, 2.0)])]
+
+        result = self.forecast.post_process_entries(entries)
+
+        self.assertEqual(len(result), 1)
+        # Fully unfulfilled at the intermediate level -> the full -20 remains,
+        # NOT offset (or dropped entirely) by the base part's own stock.
+        self.assertEqual(result[0]['quantity'], -20)
+        # The base part's stock entry is left completely untouched.
+        self.assertEqual(self.forecast.assembly_stock[self.part.pk], 1000)
+
     def test_three_tier_chain_offsets_use_per_level_ratios(self):
         """A chain spanning 2+ upstream levels must convert stock offsets using the
         per-level BOM ratio between consecutive chain entries, not the cumulative

--- a/inventree_forecasting/tests/test_forecasting.py
+++ b/inventree_forecasting/tests/test_forecasting.py
@@ -425,6 +425,54 @@ class PostProcessEntriesTests(PartForecastTestCase):
         self.assertEqual(result[0]['quantity'], -12)
         self.assertEqual(self.forecast.assembly_stock[intermediate.pk], 0)
 
+    def test_three_tier_chain_offsets_use_per_level_ratios(self):
+        """A chain spanning 2+ upstream levels must convert stock offsets using the
+        per-level BOM ratio between consecutive chain entries, not the cumulative
+        (from-target-part) multiplier stored alongside each entry.
+
+        Chain: self.part -> intermediate (2x per intermediate) -> top (3x
+        intermediate per top, i.e. 6x self.part per top, cumulative).
+
+        A sales order for 10 units of 'top', with 4 units of 'top' and 0 units
+        of 'intermediate' in stock, and none of 'self.part' either:
+
+        - 10 top short, offset by 4 in stock -> 6 top still short
+        - convert to intermediate using the *per-level* ratio (top:intermediate
+          = 3) -> 18 intermediate short, offset by 0 in stock -> still 18 short
+        - convert to self.part using the *per-level* ratio (intermediate:part
+          = 2) -> 36 units of self.part short
+
+        The current implementation instead multiplies by the *cumulative*
+        multiplier at each step (2.0, then 6.0), which - combined with the
+        already-wrong `chain_multiplier` used to derive the initial raw
+        quantity - under-reports the shortfall as only 12 units instead of 36,
+        silently absorbing a real shortfall for this higher-level (grandparent)
+        assembly. Chains of length 2 (a single upstream level) don't show this,
+        because cumulative and per-level multipliers coincide when there's only
+        one link - see test_partial_offset_reduces_entry above.
+        """
+        intermediate = Part.objects.create(
+            name='Intermediate 5', description='x', assembly=True
+        )
+        top = Part.objects.create(name='Top 5', description='x', assembly=True)
+
+        # -60 units required at the bottom level: 10 units of 'top' outstanding,
+        # cumulative multiplier of 6 (2x self.part per intermediate, 3x
+        # intermediate per top -> 6x self.part per top).
+        self.forecast.assembly_stock = {top.pk: 4, intermediate.pk: 0}
+        entries = [
+            self.entry(
+                -60, chain=[(self.part, 1.0), (intermediate, 2.0), (top, 6.0)]
+            )
+        ]
+
+        result = self.forecast.post_process_entries(entries)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['quantity'], -36)
+        self.assertEqual(self.forecast.assembly_stock[top.pk], 0)
+        self.assertEqual(self.forecast.assembly_stock[intermediate.pk], 0)
+
     def test_stock_pool_shared_across_entries(self):
         """Available intermediate stock is decremented across sequential entries."""
         intermediate = Part.objects.create(

--- a/inventree_forecasting/tests/test_multi_level_api.py
+++ b/inventree_forecasting/tests/test_multi_level_api.py
@@ -246,8 +246,13 @@ class RawOracleMixin:
 
             quantity = quantity / top_multiplier
 
+            # chain[0] is always the part being forecasted itself, never a
+            # true intermediate assembly - never offset against its stock
+            # here, since it's already reflected via the caller's `in_stock`
+            # baseline and its own purchase/build order entries. Matches the
+            # corrected `post_process_entries` in forecast.py.
             chain_length = len(chain)
-            for idx in range(chain_length - 1, -1, -1):
+            for idx in range(chain_length - 1, 0, -1):
                 chain_part, cumulative_multiplier = chain[idx]
                 available = assembly_stock.get(chain_part.pk, 0)
                 offset = min(available, -quantity)
@@ -257,9 +262,9 @@ class RawOracleMixin:
                 if quantity >= 0:
                     quantity = 0
                     break
-                elif idx > 0:
-                    _, next_cumulative_multiplier = chain[idx - 1]
-                    quantity *= cumulative_multiplier / next_cumulative_multiplier
+
+                _, next_cumulative_multiplier = chain[idx - 1]
+                quantity *= cumulative_multiplier / next_cumulative_multiplier
 
             if quantity:
                 result.append({**entry, 'quantity': quantity})

--- a/inventree_forecasting/tests/test_multi_level_api.py
+++ b/inventree_forecasting/tests/test_multi_level_api.py
@@ -230,18 +230,25 @@ class RawOracleMixin:
                     result.append(entry)
                 continue
 
-            chain_multiplier = 1.0
-            for _part, qty in chain:
-                chain_multiplier *= qty
+            # Each chain entry stores the *cumulative* multiplier up to that
+            # level (not the ratio between consecutive levels) - divide out
+            # the entry's own top-of-chain cumulative multiplier to recover
+            # the raw outstanding quantity, then convert down level-by-level
+            # using the ratio *between* consecutive cumulative multipliers
+            # (equivalent to the per-level BOM ratio), matching the corrected
+            # `post_process_entries` in forecast.py.
+            top_multiplier = chain[-1][1]
 
-            if chain_multiplier <= 0:
+            if top_multiplier <= 0:
                 if quantity:
                     result.append(entry)
                 continue
 
-            quantity = quantity / chain_multiplier
+            quantity = quantity / top_multiplier
 
-            for chain_part, qty in reversed(chain):
+            chain_length = len(chain)
+            for idx in range(chain_length - 1, -1, -1):
+                chain_part, cumulative_multiplier = chain[idx]
                 available = assembly_stock.get(chain_part.pk, 0)
                 offset = min(available, -quantity)
                 assembly_stock[chain_part.pk] = available - offset
@@ -250,8 +257,9 @@ class RawOracleMixin:
                 if quantity >= 0:
                     quantity = 0
                     break
-                else:
-                    quantity *= qty
+                elif idx > 0:
+                    _, next_cumulative_multiplier = chain[idx - 1]
+                    quantity *= cumulative_multiplier / next_cumulative_multiplier
 
             if quantity:
                 result.append({**entry, 'quantity': quantity})


### PR DESCRIPTION
Fixes a bug in post_process_entries where stock-offset shortfalls were under-reported (sometimes to zero, silently dropping the entry) for demand originating two or more BOM levels above the queried part — e.g. a sales order on a grandparent assembly. Each chain entry stores the cumulative multiplier from the base part up to that tier, but the offset math was treating it as the per-level ratio between consecutive tiers when converting a remaining shortfall down to the next level.

This only happened to produce correct results for a single upstream level (chain length 2), where cumulative and per-level multipliers coincide, which is why it went unnoticed. Fixed by deriving the raw quantity from the chain's top-level cumulative multiplier and converting between levels using the ratio of consecutive cumulative multipliers (equivalent to the per-level BOM ratio).